### PR TITLE
[FIX] Fix UnicodeDecodeError 

### DIFF
--- a/openpay/http_client.py
+++ b/openpay/http_client.py
@@ -105,7 +105,7 @@ class RequestsClient(HTTPClient):
             # This causes the content to actually be read, which could cause
             # e.g. a socket timeout. TODO: The other fetch methods probably
             # are succeptible to the same and should be updated.
-            content = result.content
+            content = result.content.decode('utf-8')
 
             status_code = result.status_code
         except Exception as e:


### PR DESCRIPTION
Fix UnicodeDecodeError generated when content has latin accented vowels or other non-ascii characters.

As in the following response: 
`'{"category":"request","description":"email no puede estar vac\xc3\xado","http_code":400,"error_code":1001,"request_id":"afe0b7b8-7387-4500-bea3-2eee3ebea849"}'`

Before this change `content['description']` was `"email no puede estar vac\xc3\xado"`; but this generated an `UnicodeDecodeError` exception at openpay/error.py(44)__init__().

Now `content['description']` is `u"email no puede estar vac\xedo"` which prints correctly as "email no puede estar vacío".

Call stack was:
openpay/resource.py(300)create()
openpay/api.py(78)request()
openpay/api.py(183)interpret_response()
openpay/api.py(86)handle_api_error()
openpay/error.py(44)__init__()