### PR TITLE
fix: disable verbose logger

### DIFF
--- a/openpay/util.py
+++ b/openpay/util.py
@@ -3,6 +3,7 @@ import logging
 import sys
 
 logger = logging.getLogger('stripe')
+logger.addHandler(logging.NullHandler()) # https://docs.python-guide.org/writing/logging/#logging-in-a-library
 
 __all__ = ['utf8']
 


### PR DESCRIPTION
The default configuration of this is logging
sensitive information. This fix is
guided as for the ofitial documentation about
library loggers https://docs.python-guide.org/writing/logging/#logging-in-a-library